### PR TITLE
Various Forge changes

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,13 +1,16 @@
 package me.jellysquid.mods.sodium.client;
 
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
+import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 import java.io.IOException;
 
+import net.minecraftforge.network.NetworkConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +35,7 @@ public class SodiumClientMod {
         CONFIG = loadConfig();
         flywheelLoaded = ModList.get().isLoaded("flywheel");
         oculusLoaded = ModList.get().isLoaded("oculus");
+        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
     }
 
     public static SodiumGameOptions options() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,16 +1,13 @@
 package me.jellysquid.mods.sodium.client;
 
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
-import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModList;
-import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 import java.io.IOException;
 
-import net.minecraftforge.network.NetworkConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +32,6 @@ public class SodiumClientMod {
         CONFIG = loadConfig();
         flywheelLoaded = ModList.get().isLoaded("flywheel");
         oculusLoaded = ModList.get().isLoaded("oculus");
-        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
     }
 
     public static SodiumGameOptions options() {

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumPreLaunch.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumPreLaunch.java
@@ -2,6 +2,8 @@ package me.jellysquid.mods.sodium.client;
 
 import net.fabricmc.loader.api.SemanticVersion;
 import net.fabricmc.loader.api.VersionParsingException;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.system.Configuration;
@@ -14,10 +16,10 @@ public class SodiumPreLaunch {
     private static final Logger LOGGER = LogManager.getLogger("Rubidium");
 
     public static void onPreLaunch() {
-        checkJemalloc();
+        DistExecutor.unsafeCallWhenOn(Dist.CLIENT, () -> SodiumPreLaunch::checkJemalloc);
     }
 
-    private static void checkJemalloc() {
+    private static Object checkJemalloc() {
         // LWJGL 3.2.3 ships Jemalloc 5.2.0 which seems to be broken on Windows and suffers from critical memory leak problems
         // Using the system allocator prevents memory leaks and other problems
         // See changelog here: https://github.com/jemalloc/jemalloc/releases/tag/5.2.1
@@ -28,6 +30,7 @@ public class SodiumPreLaunch {
                 Configuration.MEMORY_ALLOCATOR.set("system");
             }
         }
+        return null;
     }
 
     private static boolean isVersionWithinRange(String curStr, String minStr, String maxStr) {


### PR DESCRIPTION
This pull request prevents the mod from loading a client side only class on a server, immediately crashing it.
Not sure if this behavior is wanted seeing that the mod is client sided only however. 

It also makes the server ignore the mod if it is missing, removing the incompatible mod list icon from the server list.