### PR TITLE
Add "minVersion" property

### DIFF
--- a/src/main/resources/rubidium.mixins.json
+++ b/src/main/resources/rubidium.mixins.json
@@ -2,6 +2,7 @@
   "package": "me.jellysquid.mods.sodium.mixin",
   "refmap": "rubidium-refmap.json",
   "required": true,
+  "minVersion": "0.0.0",
   "compatibilityLevel": "JAVA_17",
   "plugin": "me.jellysquid.mods.sodium.mixin.SodiumMixinPlugin",
   "injectors": {


### PR DESCRIPTION
Usually Forge asks for:

Mixin config rubidium.mixins.json does not specify "minVersion" property

And people might think it's because of this that it crashes, but that's not true, so why not just add it so it removes the warning.