### PR TITLE
Fix gradle dependencies, switch to Cursemaven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,12 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-
+	maven {
+		url "https://cursemaven.com"
+		content {
+			includeGroup "curse.maven"
+		}
+	}
 }
 
 dependencies {
@@ -30,8 +35,9 @@ dependencies {
 	forge "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 	
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	compileOnly files("libs/Flywheel-Forge-1.18-0.6.0.53.jar")
-	compileOnly files("libs/ImmersiveEngineering-1.18.2-8.0.2-149.jar")
+	modCompileOnly "curse.maven:flywheel-486392:3687357"
+	modCompileOnly "curse.maven:immersive-engineering-231951:3823066"
+	modCompileOnly "curse.maven:oculus-581495:3929520"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,3 @@ org.gradle.jvmargs=-Xmx3G
 	forge_version=40.0.2
 
 	loom.platform=forge
-	
-# Dependencies
-	fabric_version=0.47.8+1.18.2
-	flywheel_version=1.18-0.6.0.17


### PR DESCRIPTION
Closes #244, closes #177, closes #74

Compile only dependencies now use Curse Maven (https://www.cursemaven.com/), which means anyone should be able to compile the project without any dependency errors going forward. It also makes it easier for developers to contribute, as the dependencies no longer have to be downloaded manually.

`compileOnly` has been changed to `modCompileOnly`, this effectively works the same as `fg.deobf` but for Architectury, as far as I know.

Flywheel has been updated to 0.6.1, although this makes no difference in how the compatibility class functions.

Oculus 1.18.2-1.2.5a has been added as a compile only dependency to resolve the error in `ChunkRenderRebuildTask`.