### PR TITLE
fix: #297 index out of bounds

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSectionCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/cloned/ClonedChunkSectionCache.java
@@ -17,7 +17,7 @@ public class ClonedChunkSectionCache {
         this.world = world;
     }
 
-    public ClonedChunkSection acquire(int x, int y, int z) {
+    public synchronized ClonedChunkSection acquire(int x, int y, int z) {
         long key = ChunkSectionPos.asLong(x, y, z);
         ClonedChunkSection section = this.byPosition.get(key);
 
@@ -45,13 +45,13 @@ public class ClonedChunkSectionCache {
 
         ChunkSectionPos pos = ChunkSectionPos.from(x, y, z);
 	    section.init(this.world, pos);
-	    
+
 	    this.byPosition.put(pos.asLong(), section);
 
         return section;
     }
 
-    public void invalidate(int x, int y, int z) {
+    public synchronized void invalidate(int x, int y, int z) {
         this.byPosition.remove(ChunkSectionPos.asLong(x, y, z));
     }
 


### PR DESCRIPTION
With the input from the sodium development team, and my own team, we've tracked down the rare and annoying index out of bounds on the `Long2ReferenceOpenHashMap` `rehash` method. From what we can tell, this is caused by the invalidation happening on a separate thread. Using `synchronized` on the two accessed methods seems to fix this.

With this fix, all of our testers have stopped having this crash :D 