### PR TITLE
Fix checking if adjacent side is solid using wrong position

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
@@ -49,7 +49,7 @@ public class BlockOcclusionCache {
                 if (adjShape.isEmpty()){
                     return true; //example: top face of potted plants if top slab is placed above
                 }
-                else if (!adjState.isSideSolid(view,pos,facing.getOpposite(), SideShapeType.FULL)){
+                else if (!adjState.isSideSolid(view,adjPos,facing.getOpposite(), SideShapeType.FULL)){
                     return true; //example: face of potted plants rendered if top stair placed above
                 }
             }


### PR DESCRIPTION
When testing some misc stuff I noticed some error logging of mine getting printed showing that the block being queried and the data at the position did not match. I didn't actually test to validate this fixes it, but it should as it is just passing the position of the adj state to it when querying information about the state in that position.