### PR TITLE
Fix glitch with textures placed at the atlas border

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,20 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-
+    maven {
+        name "Flywheel maven"
+        url "https://maven.tterrag.com/"
+    }
+    maven {
+        name "Immersive Engineering maven"
+        url "https://maven.blamejared.com"
+    }
+    maven {
+        url "https://cfa2.cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
 }
 
 dependencies {
@@ -30,8 +43,9 @@ dependencies {
 	forge "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 	
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	compileOnly files("libs/Flywheel-Forge-1.18-0.6.0.53.jar")
-	compileOnly files("libs/ImmersiveEngineering-1.18.2-8.0.2-149.jar")
+	modCompileOnly "com.jozufozu.flywheel:Flywheel-Forge:1.18-0.6.0.53"
+	modCompileOnly "blusunrize.immersiveengineering:ImmersiveEngineering:1.18.2-8.0.2-149"
+	modCompileOnly "curse.maven:oculus-581495:4354939"
 }
 
 processResources {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/sfp/ModelVertexType.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/format/sfp/ModelVertexType.java
@@ -68,7 +68,7 @@ public class ModelVertexType implements ChunkVertexType {
     }
 
     static short encodeBlockTexture(float value) {
-        return (short) (value * TEXTURE_MAX_VALUE);
+        return (short) (Math.min(0.99999997F, value) * TEXTURE_MAX_VALUE);
     }
 
     static short encodePosition(float v) {


### PR DESCRIPTION
This PR fixes rendering issues like below when textures are placed right at the "1-borders" of the atlas, such that one of the texture coordinates would be 1. In that case the previous implementation of `encodeBlockTexture` returned 0 due to an integer overflow, now it returns the correct value of -1 (since `short` is signed; this will be interpreted as 65535 later). This was fixed in Sodium in 1.19.x, I've cherry-picked their fix.

![2023-02-08_17 21 20](https://user-images.githubusercontent.com/10406104/217606927-7a5271ca-788a-4c17-be90-444a843f3905.png)

I also cleaned up the build setup, now it should be possible to compile Rubidium with just the files from the git repo. Any additional dependencies are pulled from Maven repos.

CC @MrBysco, who noticed that the glitch appeared only for textures right at the atlas border.