### PR TITLE
Fix mods, F3+A, etc. being unable to reload chunks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'dev.architectury.loom' version '1.0-SNAPSHOT'
+	id 'dev.architectury.loom' version '1.0.312'
 	id 'maven-publish'
 }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -269,7 +269,6 @@ public class SodiumOptionsGUI extends Screen {
 
         if (flags.contains(OptionFlag.REQUIRES_RENDERER_RELOAD)) {    	
             client.worldRenderer.reload();
-            SodiumWorldRenderer.hasChanges = true;
         }
 
         if (flags.contains(OptionFlag.REQUIRES_ASSET_RELOAD)) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -158,8 +158,6 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     public boolean isTerrainRenderComplete() {
         return this.chunkRenderManager.isBuildComplete();
     }
-
-    public static boolean hasChanges = false;
     
     /**
      * Called prior to any chunk rendering in order to update necessary state.
@@ -168,11 +166,6 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
         this.frustum = frustum;
 
         this.useEntityCulling = SodiumClientMod.options().advanced.useEntityCulling;
-
-        if(hasChanges) {
-            this.reload();
-            hasChanges = false;
-        }
 
         Profiler profiler = this.client.getProfiler();
         profiler.push("camera_setup");

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
@@ -34,7 +34,7 @@ public abstract class MixinWorldRenderer {
     private SodiumWorldRenderer renderer;
 
     //OK, Forge Loom don't remapping that shit
-    @Redirect(method = "func_72712_a", at = @At(value = "FIELD", target = "Lnet/minecraft/client/GameSettings;field_151451_c:I", ordinal = 1))
+    @Redirect(method = "reload()V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/option/GameOptions;viewDistance:I", ordinal = 1))
     private int nullifyBuiltChunkStorage(GameOptions options) {
         // Do not allow any resources to be allocated
         return 0;

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
@@ -145,7 +145,7 @@ public abstract class MixinWorldRenderer {
         this.renderer.scheduleRebuildForChunk(x, y, z, important);
     }
 
-    @Inject(method = "reload", at = @At("RETURN"))
+    @Inject(method = "reload()V", at = @At("RETURN"))
     private void onReload(CallbackInfo ci) {
         RenderDevice.enterManagedCode();
 

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
@@ -33,7 +33,6 @@ public abstract class MixinWorldRenderer {
 
     private SodiumWorldRenderer renderer;
 
-    //OK, Forge Loom don't remapping that shit
     @Redirect(method = "reload()V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/option/GameOptions;viewDistance:I", ordinal = 1))
     private int nullifyBuiltChunkStorage(GameOptions options) {
         // Do not allow any resources to be allocated


### PR DESCRIPTION
The real reason that the original injection into the end of `WorldRenderer.reload()` didn't work is that it was targeting the wrong `reload` method. With this fix the `hasChanges` workaround is unneeded so I've removed it.

I also took the opportunity to fix an unnecessary use of a SRG name since Loom can remap it without problems now.

This fixes #228 (finally, yay!). :tada: 