### PR TITLE
Fix item quad coloring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.gradle
+build
+run
+.vscode

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/item/MixinItemRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/item/MixinItemRenderer.java
@@ -105,6 +105,13 @@ public class MixinItemRenderer {
     }
     
     private int multARGBInts(int colorA, int colorB) {
+        // Most common case: Either quad coloring or tint-based coloring, but not both
+        if (colorA == -1) {
+            return colorB;
+        } else if (colorB == -1) {
+            return colorA;
+        }
+        // General case (rare): Both colorings, actually perform the multiplication
         int a = (int)((ColorARGB.unpackAlpha(colorA)/255.0f) * (ColorARGB.unpackAlpha(colorB)/255.0f) * 255.0f);
         int b = (int)((ColorARGB.unpackBlue(colorA)/255.0f) * (ColorARGB.unpackBlue(colorB)/255.0f) * 255.0f);
         int g = (int)((ColorARGB.unpackGreen(colorA)/255.0f) * (ColorARGB.unpackGreen(colorB)/255.0f) * 255.0f);

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/item/MixinItemRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/item/MixinItemRenderer.java
@@ -93,13 +93,7 @@ public class MixinItemRenderer {
             ModelQuadView quad = ((ModelQuadView) bakedQuad);
 
             for (int i = 0; i < 4; i++) {
-            	int fColor = color;
-                try {
-                    if (bakedQuad.hasColor()) {
-                    	fColor = multARGBInts(quad.getColor(quad.getColorIndex()), color);
-                    }
-                } catch (Exception ex) {
-                }
+                int fColor = multARGBInts(quad.getColor(i), color);
                 drain.writeQuad(entry, quad.getX(i), quad.getY(i), quad.getZ(i), fColor, quad.getTexU(i), quad.getTexV(i),
                         light, overlay, ModelQuadUtil.getFacingNormal(bakedQuad.getFace()));
             }


### PR DESCRIPTION
Forge considers the color information from the quad for all item quads, not just the ones with a tint index (see [patch](https://github.com/MinecraftForge/MinecraftForge/blob/b63dc48e19d31d1a469827a828046bbef0976300/patches/minecraft/net/minecraft/client/renderer/entity/ItemRenderer.java.patch#L47-L48)). Also, the parameter for `ModelQuadView::getColor` is the vertex index, not the tint index.

Linking BluSunrize/ImmersiveEngineering#5573.