### PR TITLE
Make block occlusion respect IForgeBlockState#hidesNeighborFace

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
@@ -35,7 +35,7 @@ public class BlockOcclusionCache {
 
         BlockState adjState = view.getBlockState(adjPos);
 
-        if (selfState.isSideInvisible(adjState, facing) || (selfState.hidesNeighborFace(view, pos, adjState, facing.getOpposite()) && selfState.supportsExternalFaceHiding())) {
+        if (selfState.isSideInvisible(adjState, facing) || (adjState.hidesNeighborFace(view, pos, adjState, facing.getOpposite()) && selfState.supportsExternalFaceHiding())) {
             return false;
         } else if (adjState.isOpaque()) {
             VoxelShape selfShape = selfState.getCullingFace(view, pos, facing);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
@@ -35,7 +35,7 @@ public class BlockOcclusionCache {
 
         BlockState adjState = view.getBlockState(adjPos);
 
-        if (selfState.isSideInvisible(adjState, facing) || selfState.supportsExternalFaceHiding() && selfState.hidesNeighborFace(view, pos, adjState, facing.getOpposite())) {
+        if (selfState.isSideInvisible(adjState, facing) || (selfState.hidesNeighborFace(view, pos, adjState, facing.getOpposite()) && selfState.supportsExternalFaceHiding())) {
             return false;
         } else if (adjState.isOpaque()) {
             VoxelShape selfShape = selfState.getCullingFace(view, pos, facing);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
@@ -35,7 +35,7 @@ public class BlockOcclusionCache {
 
         BlockState adjState = view.getBlockState(adjPos);
 
-        if (selfState.isSideInvisible(adjState, facing)) {
+        if (selfState.isSideInvisible(adjState, facing) || selfState.supportsExternalFaceHiding() && selfState.hidesNeighborFace(view, pos, adjState, facing.getOpposite())) {
             return false;
         } else if (adjState.isOpaque()) {
             VoxelShape selfShape = selfState.getCullingFace(view, pos, facing);

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/occlusion/BlockOcclusionCache.java
@@ -35,7 +35,7 @@ public class BlockOcclusionCache {
 
         BlockState adjState = view.getBlockState(adjPos);
 
-        if (selfState.isSideInvisible(adjState, facing) || (adjState.hidesNeighborFace(view, pos, adjState, facing.getOpposite()) && selfState.supportsExternalFaceHiding())) {
+        if (selfState.isSideInvisible(adjState, facing) || (adjState.hidesNeighborFace(view, pos, selfState, facing.getOpposite()) && selfState.supportsExternalFaceHiding())) {
             return false;
         } else if (adjState.isOpaque()) {
             VoxelShape selfShape = selfState.getCullingFace(view, pos, facing);


### PR DESCRIPTION
### The issue

Currently, `BlockOcclusionCache#shouldDrawSide` only relies on `BlockState#isSideInvisible` to determine whether it should cull a block's side. However, Forge introduces an additional method with a broader context, `IForgeBlockState#hidesNeighborFace`, that also accepts a `BlockView` and `BlockPos` for greater control of rendering.

Mods that rely on this method for culling will not be able to hide their blocks' faces.
<details>
<summary>Example: <b>MFFS Force Field Blocks</b> </summary>

![2023-04-08_16 59 31](https://user-images.githubusercontent.com/51261569/230728511-43ac4fce-7f1c-4c29-8fcb-64b19c2a05ee.png)
</details>

### The proposal

This PR adds support for taking this method into account when rendering blocks to match the occlusion logic of Forge.  
Source patch: https://github.com/MinecraftForge/MinecraftForge/blob/469e9a6c1afc88c8fd522ead8eae20684beb3c25/patches/minecraft/net/minecraft/world/level/block/Block.java.patch#L30

<details>
<summary><b>Resulting render</b></summary>

![2023-04-08_16 54 30](https://user-images.githubusercontent.com/51261569/230728649-13502bf9-3126-4342-a378-548435124be3.png)
</details>