### PR TITLE
Fix chunk rendering glitches+crashes with IE

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/compat/immersive/ImmersiveEmptyChunkChecker.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/compat/immersive/ImmersiveEmptyChunkChecker.java
@@ -5,14 +5,11 @@ import blusunrize.immersiveengineering.api.wires.WireCollisionData.ConnectionSeg
 import me.jellysquid.mods.sodium.client.render.chunk.RenderSection;
 import me.jellysquid.mods.sodium.client.render.chunk.tasks.ChunkRenderBuildTask;
 import me.jellysquid.mods.sodium.client.render.chunk.tasks.ChunkRenderRebuildTask;
-import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
-import me.jellysquid.mods.sodium.client.world.cloned.ClonedChunkSection;
+import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import me.jellysquid.mods.sodium.client.world.cloned.ClonedChunkSectionCache;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.util.math.BlockBox;
 import net.minecraft.util.math.ChunkSectionPos;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class ImmersiveEmptyChunkChecker {
@@ -20,20 +17,5 @@ public class ImmersiveEmptyChunkChecker {
         GlobalWireNetwork globalNet = GlobalWireNetwork.getNetwork(MinecraftClient.getInstance().world);
         List<ConnectionSegments> wiresInSection = globalNet.getCollisionData().getWiresIn(origin);
         return wiresInSection != null && !wiresInSection.isEmpty();
-    }
-
-    public static ChunkRenderBuildTask makeEmptyRebuildTask(
-            ClonedChunkSectionCache sectionCache, ChunkSectionPos origin, RenderSection render, int frame
-    ) {
-        var sections = new ClonedChunkSection[64];
-        // TODO rethink this mess, and possibly call release?
-        var centerSection = sectionCache.acquire(origin.getSectionX(), origin.getSectionY(), origin.getSectionZ());
-        Arrays.fill(sections, centerSection);
-        var sectionBB = new BlockBox(
-                origin.getMinX() - 2, origin.getMinY() - 2, origin.getMinZ() - 2,
-                origin.getMaxX() + 2, origin.getMaxY() + 2, origin.getMaxZ() + 2
-        );
-        var context = new ChunkRenderContext(origin, sections, sectionBB);
-        return new ChunkRenderRebuildTask(render, context, frame);
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -1,5 +1,7 @@
 package me.jellysquid.mods.sodium.client.world;
 
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+import me.jellysquid.mods.sodium.client.compat.immersive.ImmersiveEmptyChunkChecker;
 import me.jellysquid.mods.sodium.client.world.biome.BlockColorCache;
 import me.jellysquid.mods.sodium.client.world.cloned.ChunkRenderContext;
 import me.jellysquid.mods.sodium.client.world.cloned.ClonedChunkSection;
@@ -97,7 +99,11 @@ public class WorldSlice implements BlockRenderView {
         // If the chunk section is absent or empty, simply terminate now. There will never be anything in this chunk
         // section to render, so we need to signal that a chunk render task shouldn't created. This saves a considerable
         // amount of time in queueing instant build tasks and greatly accelerates how quickly the world can be loaded.
-        if (section == null || section.isEmpty()) {
+        boolean isEmpty = section == null || section.isEmpty();
+        if (isEmpty && SodiumClientMod.immersiveLoaded) {
+            isEmpty = !ImmersiveEmptyChunkChecker.hasWires(origin);
+        }
+        if (isEmpty) {
             return null;
         }
 


### PR DESCRIPTION
The `ChunkRenderContext` created in `ImmersiveEmptyChunkChecker::makeEmptyRebuildTask` had 64 references to the same chunk section rather than to 64 individual sections. This was not a problem when Sodium/Rubidium just leaked all `ClonedChunkSection`s, but since 3048d8f975471e80982c63672ee63ab083cd1d63 this caused the section to be released 64 times. That essentially broke reference counting on it and caused it to be re-used for different sections at once on multiple threads. With these changes sections which are empty except for wires are treated the same as other non-empty sections.