### PR TITLE
Fix crash when disabling `fast_biome_colors` feature with new mod overrides option.

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinClientWorld.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinClientWorld.java
@@ -1,17 +1,39 @@
 package me.jellysquid.mods.sodium.mixin.features.chunk_rendering;
 
+import java.util.function.Supplier;
 import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
+import me.jellysquid.mods.sodium.client.world.BiomeSeedProvider;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.registry.RegistryEntry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientWorld.class)
-public class MixinClientWorld {
+public class MixinClientWorld implements BiomeSeedProvider
+{
+    @Unique
+    private long biomeSeed;
+
     @Inject(method = "markChunkRenderability", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/WorldChunk;setShouldRenderOnUpdate(Z)V", shift = At.Shift.AFTER))
     private void postLightUpdate(int chunkX, int chunkZ, CallbackInfo ci) {
         SodiumWorldRenderer.instance()
                 .onChunkLightAdded(chunkX, chunkZ);
+    }
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void captureSeed(ClientPlayNetworkHandler netHandler, ClientWorld.Properties properties, RegistryKey<World> registryRef, RegistryEntry registryEntry, int loadDistance, int simulationDistance, Supplier profiler, WorldRenderer worldRenderer, boolean debugWorld, long seed, CallbackInfo ci) {
+        this.biomeSeed = seed;
+    }
+
+    @Override
+    public long getBiomeSeed() {
+        return this.biomeSeed;
     }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/fast_biome_colors/MixinClientWorld.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/fast_biome_colors/MixinClientWorld.java
@@ -1,44 +1,22 @@
 package me.jellysquid.mods.sodium.mixin.features.fast_biome_colors;
 
 import me.jellysquid.mods.sodium.client.util.color.FastCubicSampler;
-import me.jellysquid.mods.sodium.client.world.BiomeSeedProvider;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.CubicSampler;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.registry.RegistryEntry;
-import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 @Mixin(ClientWorld.class)
-public class MixinClientWorld implements BiomeSeedProvider {
-    @Unique
-    private long biomeSeed;
-
-    @Inject(method = "<init>", at = @At("RETURN"))
-    private void captureSeed(ClientPlayNetworkHandler netHandler, ClientWorld.Properties properties, RegistryKey<World> registryRef, RegistryEntry registryEntry, int loadDistance, int simulationDistance, Supplier profiler, WorldRenderer worldRenderer, boolean debugWorld, long seed, CallbackInfo ci) {
-        this.biomeSeed = seed;
-    }
-
+public class MixinClientWorld {
     @Redirect(method = "getSkyColor", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/CubicSampler;sampleColor(Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/CubicSampler$RgbFetcher;)Lnet/minecraft/util/math/Vec3d;"))
     private Vec3d redirectSampleColor(Vec3d pos, CubicSampler.RgbFetcher rgbFetcher) {
         World world = (World) (Object) this;
 
         return FastCubicSampler.sampleColor(pos, (x, y, z) -> world.getBiomeForNoiseGen(x, y, z).value().getSkyColor(), Function.identity());
-    }
-
-    @Override
-    public long getBiomeSeed() {
-        return this.biomeSeed;
     }
 }


### PR DESCRIPTION
Now that #408 has been implemented, I would like to disable the `fast_biome_colors` feature in my mod. However, disabling this feature causes an unconditional crash when trying to render a world, which is rather unfortunate. The cause, is there's a mixin as part of `fast_biome_colors.MixinClientWorld` that implements `BiomeSeedProvider`, which is used in chunk rendering.

This PR moves the implementation of this mixin to another `MixinClientWorld`, which is part of the chunk rendering feature - which actually requires this mixin.

This is filed as an issue to Sodium upstream here (along with crash logs): https://github.com/CaffeineMC/sodium-fabric/issues/1577

I've tested that you can use `sodium.properties` to disable both `fast_biome_colors`, and `chunk_rendering`, and both will still function with this PR.