### PR TITLE
Update CommonVertexElement.java to fix offsets

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/transform/CommonVertexElement.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/vertex/transform/CommonVertexElement.java
@@ -50,11 +50,11 @@ public enum CommonVertexElement {
         Arrays.fill(results, -1);
 
         var elements = format.getElements();
-        var offsets = format.offsets;
+        // var offsets = format.offsets;
 
         for (int i = 0; i < elements.size(); i++) {
             var element = elements.get(i);
-            var offset = offsets.getInt(i);
+            var offset = format.getOffset(i);
 
             var type = CommonVertexElement.getCommonType(element);
 


### PR DESCRIPTION
There is an issue with the minecraft source code where the offsets field is declared private and can't be accessed by the CommonVertexElement.java: 
at 
`var offsets = format.offsets;`

Decompiled minecraft code with infused forge:
at VertexFormat.java
   `private final IntList offsets = new IntArrayList();`

But the VertexFromat class has a getOffset method that uses indexes:
`public int getOffset(int index) { return offsets.getInt(index); }`

So I've used that method to get the offsets inside of the for loop. 

The initial error I've got while trying to run minecraft:
```
Error: java.lang.IllegalAccessError: class me.jellysquid.mods.sodium.client.render.vertex.transform.CommonVertexElement tried to access private field com.mojang.blaze3d.vertex.VertexFormat.f_86013_ (me.jellysquid.mods.sodium.client.render.vertex.transform.CommonVertexElement is in module rubidium@0.6.5 of loader 'TRANSFORMER' @19bedeb8; com.mojang.blaze3d.vertex.VertexFormat is in module minecraft@1.20.1 of loader 'TRANSFORMER' @19bedeb8)
```

Minecraft version 1.20.1 
Forge version: forge-1.20.1-47.1.0

Related issue:
https://github.com/Asek3/Rubidium/issues/543