### PR TITLE
[1.18.2] Cache `RenderLayer#getBlockLayers` to avoid constant memory leak

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,6 +1,5 @@
 package me.jellysquid.mods.sodium.client;
 
-import com.google.common.collect.Lists;
 import me.jellysquid.mods.sodium.client.compat.immersive.ImmersiveConnectionRenderer;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import net.minecraft.client.render.RenderLayer;
@@ -30,14 +29,12 @@ public class SodiumClientMod {
 
     public static final String MODID = "rubidium";
 
-    public static List<RenderLayer> renderLayers = Lists.newArrayList();
+    public static List<RenderLayer> renderLayers = RenderLayer.getBlockLayers();
     
     public static boolean flywheelLoaded = false;
     public static boolean immersiveLoaded = FMLLoader.getLoadingModList().getModFileById("immersiveengineering") != null;
     
     public SodiumClientMod() {
-        renderLayers = RenderLayer.getBlockLayers();
-        
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         MinecraftForge.EVENT_BUS.addListener(this::registerReloadListener);
         MOD_VERSION = ModList.get().getModContainerById(MODID).get().getModInfo().getVersion().toString();

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -29,7 +29,7 @@ public class SodiumClientMod {
 
     public static final String MODID = "rubidium";
 
-    public static List<RenderLayer> renderLayers = RenderLayer.getBlockLayers();
+    public static final List<RenderLayer> renderLayers = RenderLayer.getBlockLayers();
     
     public static boolean flywheelLoaded = false;
     public static boolean immersiveLoaded = FMLLoader.getLoadingModList().getModFileById("immersiveengineering") != null;

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,7 +1,9 @@
 package me.jellysquid.mods.sodium.client;
 
+import com.google.common.collect.Lists;
 import me.jellysquid.mods.sodium.client.compat.immersive.ImmersiveConnectionRenderer;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.fml.IExtensionPoint;
@@ -26,11 +28,14 @@ public class SodiumClientMod {
     private static String MOD_VERSION;
 
     public static final String MODID = "rubidium";
+
+    public static List<RenderLayer> renderLayers = Lists.newArrayList();
     
     public static boolean flywheelLoaded = false;
     public static boolean immersiveLoaded = FMLLoader.getLoadingModList().getModFileById("immersiveengineering") != null;
     
     public SodiumClientMod() {
+        renderLayers = RenderLayer.getBlockLayers();
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         MinecraftForge.EVENT_BUS.addListener(this::registerReloadListener);
         MOD_VERSION = ModList.get().getModContainerById(MODID).get().getModInfo().getVersion().toString();

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -36,6 +36,7 @@ public class SodiumClientMod {
     
     public SodiumClientMod() {
         renderLayers = RenderLayer.getBlockLayers();
+        
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         MinecraftForge.EVENT_BUS.addListener(this::registerReloadListener);
         MOD_VERSION = ModList.get().getModContainerById(MODID).get().getModInfo().getVersion().toString();

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -16,6 +16,7 @@ import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.network.NetworkConstants;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -100,7 +100,7 @@ public class ChunkRenderRebuildTask extends ChunkRenderBuildTask {
                     boolean rendered = false;
 
                     if (blockState.getRenderType() == BlockRenderType.MODEL) {
-                        for (RenderLayer layer : RenderLayer.getBlockLayers()) {
+                        for (RenderLayer layer : SodiumClientMod.renderLayers) {
                             if (!RenderLayers.canRenderInLayer(blockState, layer)) {
                                 continue;
                             }
@@ -122,7 +122,7 @@ public class ChunkRenderRebuildTask extends ChunkRenderBuildTask {
                     FluidState fluidState = blockState.getFluidState();
 
                     if (!fluidState.isEmpty()) {
-                        for (RenderLayer layer : RenderLayer.getBlockLayers()) {
+                        for (RenderLayer layer : SodiumClientMod.renderLayers) {
                             if (!RenderLayers.canRenderInLayer(fluidState, layer)) {
                                 continue;
                             }


### PR DESCRIPTION
https://github.com/Asek3/Rubidium/issues/178