### PR TITLE
[1.16.5] Cache `RenderLayer#getBlockLayers` to avoid constant memory leak

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -27,7 +27,7 @@ public class SodiumClientMod {
 
     public static final String MODID = "rubidium";
     
-    public static List<RenderLayer> renderLayers = RenderLayer.getBlockLayers();
+    public static final List<RenderLayer> renderLayers = RenderLayer.getBlockLayers();
 
     public static boolean flywheelLoaded;
     public static boolean oculusLoaded;

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,6 +1,5 @@
 package me.jellysquid.mods.sodium.client;
 
-import com.google.common.collect.Lists;
 import me.jellysquid.mods.sodium.client.compat.ccl.CCLCompat;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
 import net.minecraft.client.render.RenderLayer;

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -13,6 +13,8 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.fml.network.FMLNetworkConstants;
 
+import java.util.List;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -1,7 +1,9 @@
 package me.jellysquid.mods.sodium.client;
 
+import com.google.common.collect.Lists;
 import me.jellysquid.mods.sodium.client.compat.ccl.CCLCompat;
 import me.jellysquid.mods.sodium.client.gui.SodiumGameOptions;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -24,11 +26,15 @@ public class SodiumClientMod {
 
     public static final String MODID = "rubidium";
     
+    public static List<RenderLayer> renderLayers = Lists.newArrayList();
+
     public static boolean flywheelLoaded;
     public static boolean oculusLoaded;
     public static boolean cclLoaded;
     
-    public SodiumClientMod() {
+    public SodiumClientMod() {    
+        renderLayers = RenderLayer.getBlockLayers();
+        
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onInitializeClient);
         
         ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));

--- a/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/SodiumClientMod.java
@@ -28,15 +28,13 @@ public class SodiumClientMod {
 
     public static final String MODID = "rubidium";
     
-    public static List<RenderLayer> renderLayers = Lists.newArrayList();
+    public static List<RenderLayer> renderLayers = RenderLayer.getBlockLayers();
 
     public static boolean flywheelLoaded;
     public static boolean oculusLoaded;
     public static boolean cclLoaded;
     
     public SodiumClientMod() {    
-        renderLayers = RenderLayer.getBlockLayers();
-        
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onInitializeClient);
         
         ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/compile/ChunkBuildBuffers.java
@@ -42,7 +42,7 @@ public class ChunkBuildBuffers {
 
         this.offset = new ChunkModelOffset();
 
-        for (RenderLayer layer : RenderLayer.getBlockLayers()) {
+        for (RenderLayer layer : SodiumClientMod.renderLayers) {
             int passId = this.renderPassManager.getRenderPassId(layer);
 
             VertexBufferBuilder[] buffers = this.buffersByLayer[passId];

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/tasks/ChunkRenderRebuildTask.java
@@ -94,7 +94,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                     buffers.setRenderOffset(pos.getX() - renderOffset.getX(), pos.getY() - renderOffset.getY(), pos.getZ() - renderOffset.getZ());
 
                     if (blockState.getRenderType() == BlockRenderType.MODEL) {
-                    for (RenderLayer layer : RenderLayer.getBlockLayers()) {
+                    for (RenderLayer layer : SodiumClientMod.renderLayers) {
 	                        if (!RenderLayers.canRenderInLayer(blockState, layer)) {
 	                        	continue;
 	                        }
@@ -122,7 +122,7 @@ public class ChunkRenderRebuildTask<T extends ChunkGraphicsState> extends ChunkR
                     FluidState fluidState = blockState.getFluidState();
 
                     if (!fluidState.isEmpty()) {
-                        for (RenderLayer layer : RenderLayer.getBlockLayers()) {
+                        for (RenderLayer layer : SodiumClientMod.renderLayers) {
                             if (!RenderLayers.canRenderInLayer(fluidState, layer)) {
                                 continue;
                             }


### PR DESCRIPTION
fix https://github.com/Asek3/Rubidium/issues/333